### PR TITLE
Link HTML pages for basic navigation flow

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -20,11 +20,13 @@
     >
       <div>
         <div class="flex items-center bg-white p-4 pb-2 justify-between">
-          <div class="text-[#161412] flex size-12 shrink-0 items-center" data-icon="ArrowLeft" data-size="24px" data-weight="regular">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-              <path d="M224,128a8,8,0,0,1-8,8H59.31l58.35,58.34a8,8,0,0,1-11.32,11.32l-72-72a8,8,0,0,1,0-11.32l72-72a8,8,0,0,1,11.32,11.32L59.31,120H216A8,8,0,0,1,224,128Z"></path>
-            </svg>
-          </div>
+          <a href="gallery.html">
+            <div class="text-[#161412] flex size-12 shrink-0 items-center" data-icon="ArrowLeft" data-size="24px" data-weight="regular">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                <path d="M224,128a8,8,0,0,1-8,8H59.31l58.35,58.34a8,8,0,0,1-11.32,11.32l-72-72a8,8,0,0,1,0-11.32l72-72a8,8,0,0,1,11.32,11.32L59.31,120H216A8,8,0,0,1,224,128Z"></path>
+              </svg>
+            </div>
+          </a>
           <h2 class="text-[#161412] text-lg font-bold leading-tight tracking-[-0.015em] flex-1 text-center">Whiskers</h2>
           <div class="flex w-12 items-center justify-end">
             <button
@@ -125,7 +127,7 @@
       </div>
       <div>
         <div class="flex gap-2 border-t border-[#f4f2f1] bg-white px-4 pb-3 pt-2">
-          <a class="just flex flex-1 flex-col items-center justify-end gap-1 rounded-full text-[#161412]" href="#">
+          <a class="just flex flex-1 flex-col items-center justify-end gap-1 rounded-full text-[#161412]" href="gallery.html">
             <div class="text-[#161412] flex h-8 items-center justify-center" data-icon="House" data-size="24px" data-weight="fill">
               <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                 <path
@@ -141,7 +143,7 @@
               </svg>
             </div>
           </a>
-          <a class="just flex flex-1 flex-col items-center justify-end gap-1 text-[#81766a]" href="#">
+          <a class="just flex flex-1 flex-col items-center justify-end gap-1 text-[#81766a]" href="upload.html">
             <div class="text-[#81766a] flex h-8 items-center justify-center" data-icon="Plus" data-size="24px" data-weight="regular">
               <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
                 <path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path>

--- a/gallery.html
+++ b/gallery.html
@@ -43,13 +43,13 @@
         </div>
         <h3 class="text-[#161412] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">June 12, 2024</h3>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(158px,1fr))] gap-3 p-4">
-          <div class="flex flex-col gap-3 pb-3">
+          <a href="detail.html" class="flex flex-col gap-3 pb-3">
             <div
               class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
               style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuB6-5pbpEoDuigMO_tAaiVlRNGK2FiFCrUhTEYxTK2t1_Ydm5pZnua5x12gy0j0SCnzpmnp6XtI3VuXUpZt2KDWG9ZG-2xvLvGy8PYL71blN7fg28c_iw_6Vok_S4DRQ9cXRtu0SsXv_A95l4OeFtElhQa3Ioty1clvW3qZ3hgJQO4coWQPCwAb_RH6srdhN5hjTn5zc-WV550Yp6NeD-sr6aHemg7XQRo36CQhMjpo1SLaJf1KwkNxbZCzGFxs5aJbj-agmbONELga");'
             ></div>
             <p class="text-[#161412] text-base font-medium leading-normal">Whiskers in the Sun</p>
-          </div>
+          </a>
           <div class="flex flex-col gap-3 pb-3">
             <div
               class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
@@ -74,13 +74,13 @@
         </div>
         <h3 class="text-[#161412] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">June 11, 2024</h3>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(158px,1fr))] gap-3 p-4">
-          <div class="flex flex-col gap-3 pb-3">
+          <a href="detail.html" class="flex flex-col gap-3 pb-3">
             <div
               class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
               style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuC0rDeAM4woOW2aNK72Bu0o-IggrIf-5S2v5Wsx0i9vjlrUS5jZe9hR2WBGvRgLvqucUmNQPtUmUuc2v5WKGJjdKuTIHg3ZXJsy7dsXK-GXRwX7YTFl3FMQwErDCteRYbHX5sOMeNM4Xn7Mjb_qS43da2DXzifwRVZ1GV3GmJ2M0u9xHohW5Gw_Nh47WvFwR5ZarkwW0F6D3UF4OHYS-WWM575i3iN92vr04mnkmqVfx8rIztbi8CxEZpgAbm3b1ZC7FG3S5Uv7Hw1F");'
             ></div>
             <p class="text-[#161412] text-base font-medium leading-normal">Cozy Cuddle</p>
-          </div>
+          </a>
           <div class="flex flex-col gap-3 pb-3">
             <div
               class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
@@ -105,13 +105,13 @@
         </div>
         <h3 class="text-[#161412] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">June 10, 2024</h3>
         <div class="grid grid-cols-[repeat(auto-fit,minmax(158px,1fr))] gap-3 p-4">
-          <div class="flex flex-col gap-3 pb-3">
+          <a href="detail.html" class="flex flex-col gap-3 pb-3">
             <div
               class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
               style='background-image: url("https://lh3.googleusercontent.com/aida-public/AB6AXuA8D-sW_sBWpj6Oj12rONas9sZLBoWfea0gD0Azdw4ODZO1PhoEnrTmfd4RcPkhFK6p_z28s7fQoIvBy5xSwBf0KEGaQ82ip3JzGSzpBufPxmtG5b6xpuhu3K5Ssrlyxmpvd_CmnH_BZmHQISKAALIIxIOW5bnK8f5rXjxfFa6FRjZzWtx_NwrwYdA17CMpGTYRcQTPKrErH8gcANXCAGIi8y7YIPVcq-D1uj5l73gMocli2WJ77FNqWlHo4lX8pB7Dd0GSVPwwHvXZ");'
             ></div>
             <p class="text-[#161412] text-base font-medium leading-normal">Midnight Meow</p>
-          </div>
+          </a>
           <div class="flex flex-col gap-3 pb-3">
             <div
               class="w-full bg-center bg-no-repeat aspect-square bg-cover rounded-xl"
@@ -136,6 +136,11 @@
         </div>
       </div>
       <div><div class="h-5 bg-white"></div></div>
+    <a href="upload.html" class="fixed bottom-6 right-6 bg-[#e5ccb2] text-[#161412] p-4 rounded-full shadow-lg flex items-center justify-center" style="z-index: 1000;">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+        <path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"></path>
+      </svg>
+    </a>
     </div>
   </body>
 </html>

--- a/intro.html
+++ b/intro.html
@@ -46,16 +46,18 @@
       <div>
         <div class="flex justify-center">
           <div class="flex flex-1 gap-3 max-w-[480px] flex-col items-stretch px-4 py-3">
-            <button
+            <a
+              href="login.html"
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-5 bg-[#e5ccb2] text-[#161412] text-base font-bold leading-normal tracking-[0.015em] w-full"
             >
               <span class="truncate">Log In</span>
-            </button>
-            <button
+            </a>
+            <a
+              href="gallery.html"
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-5 bg-[#f4f2f1] text-[#161412] text-base font-bold leading-normal tracking-[0.015em] w-full"
             >
               <span class="truncate">Guest</span>
-            </button>
+            </a>
           </div>
         </div>
         <div class="h-5 bg-white"></div>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link
+      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
+      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900&amp;family=Plus+Jakarta+Sans%3Awght%40400%3B500%3B700%3B800"
+    />
+    <title>Login - Catstagram</title>
+    <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+</head>
+<body class="bg-white" style='font-family: "Plus Jakarta Sans", "Noto Sans", sans-serif;'>
+    <div class="relative flex size-full min-h-screen flex-col items-center justify-center bg-white p-4">
+        <div class="w-full max-w-md space-y-6">
+            <h1 class="text-[#161412] text-3xl font-bold leading-tight tracking-[-0.015em] text-center">Catstagram Login</h1>
+
+            <div class="space-y-4">
+                <div>
+                    <label for="username" class="text-[#161412] text-base font-medium leading-normal">Username</label>
+                    <input
+                        type="text"
+                        id="username"
+                        name="username"
+                        placeholder="Enter your username"
+                        class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#161412] focus:outline-0 focus:ring-0 border border-[#e3e1dd] bg-white focus:border-[#e3e1dd] h-14 placeholder:text-[#81766a] p-[15px] text-base font-normal leading-normal"
+                    />
+                </div>
+
+                <div>
+                    <label for="password" class="text-[#161412] text-base font-medium leading-normal">Password</label>
+                    <input
+                        type="password"
+                        id="password"
+                        name="password"
+                        placeholder="Enter your password"
+                        class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#161412] focus:outline-0 focus:ring-0 border border-[#e3e1dd] bg-white focus:border-[#e3e1dd] h-14 placeholder:text-[#81766a] p-[15px] text-base font-normal leading-normal"
+                    />
+                </div>
+            </div>
+
+            <a
+              href="gallery.html"
+              class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-5 bg-[#e5ccb2] text-[#161412] text-base font-bold leading-normal tracking-[0.015em] w-full"
+            >
+              <span class="truncate">Log In</span>
+            </a>
+
+            <p class="text-center text-sm text-[#81766a]">
+                Go back to <a href="intro.html" class="font-medium text-[#e5ccb2] hover:text-[#d4bda1]">Intro Page</a>
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/upload.html
+++ b/upload.html
@@ -20,13 +20,15 @@
     >
       <div>
         <div class="flex items-center bg-white p-4 pb-2 justify-between">
-          <div class="text-[#161412] flex size-12 shrink-0 items-center" data-icon="X" data-size="24px" data-weight="regular">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
-              <path
-                d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
-              ></path>
-            </svg>
-          </div>
+          <a href="gallery.html">
+            <div class="text-[#161412] flex size-12 shrink-0 items-center" data-icon="X" data-size="24px" data-weight="regular">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" fill="currentColor" viewBox="0 0 256 256">
+                <path
+                  d="M205.66,194.34a8,8,0,0,1-11.32,11.32L128,139.31,61.66,205.66a8,8,0,0,1-11.32-11.32L116.69,128,50.34,61.66A8,8,0,0,1,61.66,50.34L128,116.69l66.34-66.35a8,8,0,0,1,11.32,11.32L139.31,128Z"
+                ></path>
+              </svg>
+            </div>
+          </a>
           <h2 class="text-[#161412] text-lg font-bold leading-tight tracking-[-0.015em] flex-1 text-center pr-12">Upload Photo</h2>
         </div>
         <p class="text-[#161412] text-base font-normal leading-normal pb-3 pt-1 px-4 text-center">Upload a photo of your cat</p>
@@ -85,11 +87,12 @@
       </div>
       <div>
         <div class="flex px-4 py-3">
-          <button
+          <a
+            href="gallery.html"
             class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-12 px-5 flex-1 bg-[#e5ccb2] text-[#161412] text-base font-bold leading-normal tracking-[0.015em]"
           >
             <span class="truncate">Upload</span>
-          </button>
+          </a>
         </div>
         <div class="h-5 bg-white"></div>
       </div>


### PR DESCRIPTION
This commit introduces the following page linking:

- Created `login.html` for your authentication.
- `intro.html`:
    - "Log In" button now links to `login.html`.
    - "Guest" button now links to `gallery.html`.
- `login.html`:
    - "Log In" button (after form) links to `gallery.html`.
- `gallery.html`:
    - Images (first in each date group representatively) now link to `detail.html`.
    - Added a Floating Action Button (FAB) that links to `upload.html`.
- `upload.html`:
    - "Upload" button now links back to `gallery.html`.
    - "X" (close) button now links back to `gallery.html`.
- `detail.html`:
    - Back arrow now links to `gallery.html`.
    - "Home" icon in the bottom navigation bar now links to `gallery.html`.
    - "Plus" (Add) icon in the bottom navigation bar now links to `upload.html`.

This primarily sets up the href attributes for anchor tags to simulate page transitions. No backend logic or JavaScript functionality is implemented in this commit.